### PR TITLE
Remove use of keystore.hasKey to improve performance

### DIFF
--- a/src/identity-provider.js
+++ b/src/identity-provider.js
@@ -27,10 +27,11 @@ class IdentityProvider {
   }
 
   async sign (identity, data) {
-    if (!this._keystore.hasKey(identity.id))
+    const signingKey = await this._keystore.getKey(identity.id)
+
+    if (!signingKey)
       throw new Error(`Private signing key not found from Keystore`)
 
-    const signingKey = await this._keystore.getKey(identity.id)
     const signature = await this._keystore.sign(signingKey, data)
     return signature
   }


### PR DESCRIPTION
This PR will cahange .sign function so that we remove the call to keystore.hasKey.

The commit says:
*keystore.getKey returns either the key or undefined if key was not found, so we can throw the exception based on having found the key or not. this in turn means one call less to keystore's storage (localStorage) and io, which improves the performance of log appends significantly.*

The difference can be observed by running `node benchmarks/benchmark-append.js` before and after applying this commit.