### PR TITLE
Create identity with one call

### DIFF
--- a/src/identity-provider.js
+++ b/src/identity-provider.js
@@ -22,6 +22,11 @@ class IdentityProvider {
     return new Identity(id, publicKey, pkSignature, signature, this)
   }
 
+  static async createIdentity (keystore, id, identitySignerFn) {
+    const identityProvider = new IdentityProvider(keystore)
+    return await identityProvider.createIdentity(id, identitySignerFn)
+  }
+
   static async verifyIdentity (identity, verifierFunction) {
     return verifierFunction(identity.publicKey + identity.pkSignature, identity.signature) === identity.id
   }

--- a/src/identity-provider.js
+++ b/src/identity-provider.js
@@ -27,10 +27,11 @@ class IdentityProvider {
   }
 
   async sign (identity, data) {
-    if (!this._keystore.hasKey(identity.id))
+    const signingKey = await this._keystore.getKey(identity.id)
+
+    if (!signingKey)
       throw new Error(`Private signing key not found from Keystore`)
 
-    const signingKey = await this._keystore.getKey(identity.id)
     const signature = await this._keystore.sign(signingKey, data)
     return signature
   }


### PR DESCRIPTION
This PR will add a static method to IdentityProvider so that we can create an identity with one line from the using program.

Effectively this:
```javascript
const IdentityProvider = require('orbit-db-identity-provider')
const identityProvider = new IdentityProvider(keystore)
const identity = await IdentityProvider.createIdentity('userA', identitySignerFn)
// returns an Identity
```
becomes this:
```javascript
const IdentityProvider = require('orbit-db-identity-provider')
const identity = await IdentityProvider.createIdentity(keystore, 'userA', identitySignerFn)
// returns an Identity
```