### PR TITLE
Remove another internal call to hasKey()

### DIFF
--- a/src/identity-provider.js
+++ b/src/identity-provider.js
@@ -11,9 +11,8 @@ class IdentityProvider {
   }
 
   async createIdentity(id, signingFunction) {
-    const key = this._keystore.hasKey(id)
-      ? await this._keystore.getKey(id)
-      : await this._keystore.createKey(id)
+    const key = await this._keystore.getKey(id)
+      || await this._keystore.createKey(id)
 
     const pkSignature = await this._keystore.sign(key, id) // sign the id with the signing key we're going to use
     const publicKey = key.getPublic('hex')


### PR DESCRIPTION
This PR will change IdentityProvider's createIdentity() so that we don't call keystore.hasKey() anymore. This saves us a round trip to the storage and improves the performance of the method.

In the change, keystore.getKey() return null if key is not in the keystore, so with `||` we can then create it instead.