### PR TITLE
Feat/refactor names

### DIFF
--- a/src/identity-provider.js
+++ b/src/identity-provider.js
@@ -1,7 +1,7 @@
 'use strict'
 const isDefined = require('./is-defined')
 const Identity = require('./identity')
-const defaultType = 'odb'
+const defaultType = 'orbitdb'
 
 class IdentityProvider {
   constructor (keystore) {

--- a/src/identity-provider.js
+++ b/src/identity-provider.js
@@ -28,7 +28,7 @@ class IdentityProvider {
     const publicKey = key.getPublic('hex')
     // Sign both the key and the signature created with that key
     const signature = await identitySignerFn(id, publicKey + pkSignature)
-    return new Identity(id, publicKey, pkSignature, signature, this, type)
+    return new Identity(id, publicKey, pkSignature, signature, type, this)
   }
 
   static async createIdentity (keystore, id, identitySignerFn, type) {

--- a/src/identity-provider.js
+++ b/src/identity-provider.js
@@ -11,17 +11,17 @@ class IdentityProvider {
     this._keystore = keystore
   }
 
-  async createIdentity(id, identitySignerFn, type) {
+  async createIdentity(id, type, identitySignerFn) {
     // Get the key for id from the keystore or create one
     // if it doesn't exist
     const key = await this._keystore.getKey(id) ||
       await this._keystore.createKey(id)
     // Sign with the key for the id
     const selfSigningFn = async (id, data) => await this._keystore.sign(key, data)
-    // If signing function was not passed, use keystore as the identity signer
-    identitySignerFn = isDefined(identitySignerFn) ? identitySignerFn : selfSigningFn
     // If no type was indicated, set to default
     type = isDefined(type) ? type : defaultType
+    // If signing function was not passed, use keystore as the identity signer
+    identitySignerFn = isDefined(identitySignerFn) ? identitySignerFn : selfSigningFn
     // Sign the id with the signing key we're going to use
     const idSignature = await this._keystore.sign(key, id)
     // Get the hex string of the public key
@@ -31,9 +31,9 @@ class IdentityProvider {
     return new Identity(id, publicKey, idSignature, pubKeyIdSignature, type, this)
   }
 
-  static async createIdentity (keystore, id, identitySignerFn, type) {
+  static async createIdentity (keystore, id, type, identitySignerFn) {
     const identityProvider = new IdentityProvider(keystore)
-    return await identityProvider.createIdentity(id, identitySignerFn, type)
+    return await identityProvider.createIdentity(id, type, identitySignerFn)
   }
 
   static async verifyIdentity (identity, verifierFunction) {

--- a/src/identity-provider.js
+++ b/src/identity-provider.js
@@ -23,12 +23,12 @@ class IdentityProvider {
     // If no type was indicated, set to default
     type = isDefined(type) ? type : defaultType
     // Sign the id with the signing key we're going to use
-    const pkSignature = await this._keystore.sign(key, id)
+    const idSignature = await this._keystore.sign(key, id)
     // Get the hex string of the public key
     const publicKey = key.getPublic('hex')
     // Sign both the key and the signature created with that key
-    const signature = await identitySignerFn(id, publicKey + pkSignature)
-    return new Identity(id, publicKey, pkSignature, signature, type, this)
+    const pubKeyIdSignature = await identitySignerFn(id, publicKey + idSignature)
+    return new Identity(id, publicKey, idSignature, pubKeyIdSignature, type, this)
   }
 
   static async createIdentity (keystore, id, identitySignerFn, type) {

--- a/src/identity.js
+++ b/src/identity.js
@@ -2,7 +2,7 @@
 const isDefined = require('./is-defined')
 
 class Identity {
-  constructor (id, publicKey, pkSignature, signature, provider, type) {
+  constructor (id, publicKey, pkSignature, signature, type, provider) {
     if (!isDefined(id)) {
       throw new Error('Identity id is required')
     }
@@ -19,12 +19,12 @@ class Identity {
       throw new Error('Signature is required')
     }
 
+    if (!isDefined(type)) {
+      throw new Error('Identity type is required')
+    }
+
     if (!isDefined(provider)) {
       throw new Error('Identity provider is required')
-    }
-    
-    if (!isDefined(type)) {
-      throw new Error('Type of identity is required')
     }
 
     this._id = id
@@ -68,8 +68,8 @@ class Identity {
       id: this._id,
       publicKey: this._publicKey,
       pkSignature: this._pkSignature,
-      type: this._type,
-      signature: this._signature
+      signature: this._signature,
+      type: this._type
     }
   }
 }

--- a/src/identity.js
+++ b/src/identity.js
@@ -2,7 +2,7 @@
 const isDefined = require('./is-defined')
 
 class Identity {
-  constructor (id, publicKey, pkSignature, signature, provider) {
+  constructor (id, publicKey, pkSignature, signature, provider, type) {
     if (!isDefined(id)) {
       throw new Error('Identity id is required')
     }
@@ -22,11 +22,16 @@ class Identity {
     if (!isDefined(provider)) {
       throw new Error('Identity provider is required')
     }
+    
+    if (!isDefined(type)) {
+      throw new Error('Type of identity is required')
+    }
 
     this._id = id
     this._publicKey = publicKey
     this._pkSignature = pkSignature
     this._signature = signature
+    this._type = type
     this._provider = provider
   }
 
@@ -50,6 +55,10 @@ class Identity {
     return this._signature
   }
 
+  get type() {
+    return this._type
+  }
+
   get provider() {
     return this._provider
   }
@@ -59,6 +68,7 @@ class Identity {
       id: this._id,
       publicKey: this._publicKey,
       pkSignature: this._pkSignature,
+      type: this._type,
       signature: this._signature
     }
   }

--- a/src/identity.js
+++ b/src/identity.js
@@ -2,7 +2,7 @@
 const isDefined = require('./is-defined')
 
 class Identity {
-  constructor (id, publicKey, pkSignature, signature, type, provider) {
+  constructor (id, publicKey, idSignature, pubKeyIdSignature, type, provider) {
     if (!isDefined(id)) {
       throw new Error('Identity id is required')
     }
@@ -11,12 +11,12 @@ class Identity {
       throw new Error('Invalid public key')
     }
 
-    if (!isDefined(pkSignature)) {
-      throw new Error('Signature of the id (pkSignature) is required')
+    if (!isDefined(idSignature)) {
+      throw new Error('Signature of the id (idSignature) is required')
     }
 
-    if (!isDefined(signature)) {
-      throw new Error('Signature is required')
+    if (!isDefined(pubKeyIdSignature)) {
+      throw new Error('Signature of (publicKey + idSignature) is required')
     }
 
     if (!isDefined(type)) {
@@ -29,8 +29,7 @@ class Identity {
 
     this._id = id
     this._publicKey = publicKey
-    this._pkSignature = pkSignature
-    this._signature = signature
+    this._signatures = Object.assign({}, { id: idSignature }, { publicKey: pubKeyIdSignature } )
     this._type = type
     this._provider = provider
   }
@@ -47,12 +46,8 @@ class Identity {
     return this._publicKey
   }
 
-  get pkSignature() {
-    return this._pkSignature
-  }
-
-  get signature() {
-    return this._signature
+  get signatures() {
+    return this._signatures
   }
 
   get type() {
@@ -67,8 +62,7 @@ class Identity {
     return {
       id: this._id,
       publicKey: this._publicKey,
-      pkSignature: this._pkSignature,
-      signature: this._signature,
+      signatures: this._signatures,
       type: this._type
     }
   }

--- a/test/identity-provider.test.js
+++ b/test/identity-provider.test.js
@@ -214,7 +214,7 @@ describe('Identity Provider', function() {
 
     it('throws an error if private key is not found from keystore', async () => {
       // Remove the key from the keystore (we're using a mock storage in these tests)
-      const modifiedIdentity = new Identity('this id does not exist', identity.publicKey, '<sig>', identity.signature, identity.provider)
+      const modifiedIdentity = new Identity('this id does not exist', identity.publicKey, '<sig>', identity.signature, identity.provider, identity.type)
 
       let err
       try {

--- a/test/identity-provider.test.js
+++ b/test/identity-provider.test.js
@@ -214,7 +214,7 @@ describe('Identity Provider', function() {
 
     it('throws an error if private key is not found from keystore', async () => {
       // Remove the key from the keystore (we're using a mock storage in these tests)
-      const modifiedIdentity = new Identity('this id does not exist', identity.publicKey, '<sig>', identity.signature, identity.provider, identity.type)
+      const modifiedIdentity = new Identity('this id does not exist', identity.publicKey, '<sig>', identity.signature, identity.type, identity.provider)
 
       let err
       try {

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -25,11 +25,12 @@ describe('Identity', function() {
   const pkSignature = 'signature for <id>'
   const signature = 'signature for <pkSignature + publicKey>'
   const provider = 'IdentityProviderInstance'
+  const type = 'odb'
 
   let identity
 
   before(async () => {
-    identity = new Identity(id, publicKey, pkSignature, signature, provider)
+    identity = new Identity(id, publicKey, pkSignature, signature, provider, type)
   })
 
   it('has the correct id', async () => {
@@ -57,7 +58,8 @@ describe('Identity', function() {
       id: id,
       publicKey: publicKey,
       pkSignature: pkSignature,
-      signature: signature      
+      signature: signature,
+      type: type
     }
     assert.deepEqual(identity.toJSON(), expected)
   })

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -22,15 +22,15 @@ describe('Identity', function() {
 
   const id = '0x01234567890abcdefghijklmnopqrstuvwxyz'
   const publicKey = '<pubkey>'
-  const pkSignature = 'signature for <id>'
-  const signature = 'signature for <pkSignature + publicKey>'
-  const type = 'odb'
+  const idSignature = 'signature for <id>'
+  const publicKeyAndIdSignature = 'signature for <publicKey + idSignature>'
+  const type = 'orbitdb'
   const provider = 'IdentityProviderInstance'
 
   let identity
 
   before(async () => {
-    identity = new Identity(id, publicKey, pkSignature, signature, type, provider)
+    identity = new Identity(id, publicKey, idSignature, publicKeyAndIdSignature, type, provider)
   })
 
   it('has the correct id', async () => {
@@ -41,12 +41,12 @@ describe('Identity', function() {
     assert.equal(identity.publicKey, publicKey)
   })
 
-  it('has the correct pkSignature', async () => {
-    assert.equal(identity.pkSignature, pkSignature)
+  it('has the correct idSignature', async () => {
+    assert.equal(identity.signatures.id, idSignature)
   })
 
-  it('has the correct signature', async () => {
-    assert.equal(identity.signature, signature)
+  it('has the correct publicKeyAndIdSignature', async () => {
+    assert.equal(identity.signatures.publicKey, publicKeyAndIdSignature)
   })
 
   it('has the correct provider', async () => {
@@ -57,8 +57,7 @@ describe('Identity', function() {
     const expected = {
       id: id,
       publicKey: publicKey,
-      pkSignature: pkSignature,
-      signature: signature,
+      signatures: { id: idSignature, publicKey: publicKeyAndIdSignature },
       type: type
     }
     assert.deepEqual(identity.toJSON(), expected)
@@ -92,23 +91,23 @@ describe('Identity', function() {
       } catch (e) {
         err = e
       }
-      assert.equal(err, "Error: Signature of the id (pkSignature) is required")
+      assert.equal(err, "Error: Signature of the id (idSignature) is required")
     })
 
     it('throws and error if identity signature was not given in constructor', async () => {
       let err
       try {
-        identity = new Identity('abc', publicKey, pkSignature)
+        identity = new Identity('abc', publicKey, idSignature)
       } catch (e) {
         err = e
       }
-      assert.equal(err, "Error: Signature is required")
+      assert.equal(err, "Error: Signature of (publicKey + idSignature) is required")
     })
 
     it('throws and error if identity provider was not given in constructor', async () => {
       let err
       try {
-        identity = new Identity('abc', publicKey, pkSignature, signature, type)
+        identity = new Identity('abc', publicKey, idSignature, publicKeyAndIdSignature, type)
       } catch (e) {
         err = e
       }
@@ -118,7 +117,7 @@ describe('Identity', function() {
     it('throws and error if identity type was not given in constructor', async () => {
       let err
       try {
-        identity = new Identity('abc', publicKey, pkSignature, signature, null, provider)
+        identity = new Identity('abc', publicKey, idSignature, publicKeyAndIdSignature, null, provider)
       } catch (e) {
         err = e
       }

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -24,13 +24,13 @@ describe('Identity', function() {
   const publicKey = '<pubkey>'
   const pkSignature = 'signature for <id>'
   const signature = 'signature for <pkSignature + publicKey>'
-  const provider = 'IdentityProviderInstance'
   const type = 'odb'
+  const provider = 'IdentityProviderInstance'
 
   let identity
 
   before(async () => {
-    identity = new Identity(id, publicKey, pkSignature, signature, provider, type)
+    identity = new Identity(id, publicKey, pkSignature, signature, type, provider)
   })
 
   it('has the correct id', async () => {
@@ -108,11 +108,21 @@ describe('Identity', function() {
     it('throws and error if identity provider was not given in constructor', async () => {
       let err
       try {
-        identity = new Identity('abc', publicKey, pkSignature, signature)
+        identity = new Identity('abc', publicKey, pkSignature, signature, type)
       } catch (e) {
         err = e
       }
       assert.equal(err, "Error: Identity provider is required")
+    })
+
+    it('throws and error if identity type was not given in constructor', async () => {
+      let err
+      try {
+        identity = new Identity('abc', publicKey, pkSignature, signature, null, provider)
+      } catch (e) {
+        err = e
+      }
+      assert.equal(err, "Error: Identity type is required")
     })
   })
 })


### PR DESCRIPTION
This PR adds a type field to identity and moves pkSignature and signature to 'signatures.id' and 'signatures.publicKey' respectively

Contributes to #8 