### PR TITLE
feat: pass in keystore to OrbitDBIdentityProvider

### DIFF
--- a/src/orbit-db-identity-provider.js
+++ b/src/orbit-db-identity-provider.js
@@ -7,7 +7,7 @@ const type = 'orbitdb'
 class OrbitDBIdentityProvider extends IdentityProvider {
   constructor (options = {}) {
     super()
-    this._keystore = Keystore.create(options.identityKeysPath || identityKeysPath)
+    this._keystore = options.keystore || Keystore.create(options.identityKeysPath || identityKeysPath)
   }
 
   // Returns the type of the identity provider


### PR DESCRIPTION
Allow for a keystore to be passed in and used.

**Some context in case a better solution exists**: Stumbled across this as I was exploring the [orbit-db/orbit-db#new-acs](https://github.com/orbitdb/orbit-db/tree/feat/new-acs) branch and noticed that a new directory (`./orbitdb/identity/keys`) was being created outside of the `directory` specified in the OrbitDB instance constructor.