### PR TITLE
close keystore after signing

### DIFF
--- a/src/identities.js
+++ b/src/identities.js
@@ -51,6 +51,7 @@ class Identities {
     const key = await keystore.getKey(id) || await keystore.createKey(id)
     const publicKey = keystore.getPublic(key)
     const idSignature = await keystore.sign(key, id)
+    await this._keystore.close()
     return { publicKey, idSignature }
   }
 

--- a/src/orbit-db-identity-provider.js
+++ b/src/orbit-db-identity-provider.js
@@ -34,8 +34,10 @@ class OrbitDBIdentityProvider extends IdentityProvider {
     if (!key) {
       throw new Error(`Signing key for '${id}' not found`)
     }
+    const sig = await keystore.sign(key, data)
+    await this._keystore.close()
 
-    return keystore.sign(key, data)
+    return sig
   }
 
   static async verifyIdentity (identity) {


### PR DESCRIPTION
Closes store after signing to avoid leveldb 'lock held' error