### PR TITLE
Fixes #39. Web3 signer needs to call .getAddress() instead of address…

### DIFF
--- a/src/ethereum-identity-provider.js
+++ b/src/ethereum-identity-provider.js
@@ -17,7 +17,7 @@ class EthIdentityProvider extends IdentityProvider {
     if (!this.wallet) {
       this.wallet = await this._createWallet(options)
     }
-    return this.wallet.address
+    return this.wallet.getAddress()
   }
 
   // Returns a signature of pubkeysignature


### PR DESCRIPTION
This works in the browser after this:

```
let provider = new ethers.providers.Web3Provider(web3.currentProvider)
let signer = provider.getSigner(0)

const type = EthIdentityProvider.type

const options = {
    type: type,
    keystore: keystore,
    wallet: signer
}

let identity = await Identities.createIdentity(options)
```