### PR TITLE
Updating ethers and orbit-db-keystore

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     ]
   },
   "dependencies": {
-    "ethers": "^4.0.20",
-    "orbit-db-keystore": "~0.3.4"
+    "ethers": "^5.0.8",
+    "orbit-db-keystore": "~0.3.5"
   },
   "localMaintainers": [
     "haad <haad@haja.io>",


### PR DESCRIPTION
This PR updates ethers to v5 which transitively updates elliptic to 6.5.3, removing a security alert.