### PR TITLE
feat: Add provider for Decentralized Identifiers (DID)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ To use an existing keystore, you can pass it as an argument in the options as fo
 const identity = await Identities.createIdentity({ id: 'local-id', keystore: existingKeystore })
 ```
 
+#### Creating an identity with a DID
+Decentralized Identifiers (DID) is a common way to represent a digital identity. Below is an example using the `did:key` method (specifically [key-did-provider-ed25519](https://github.com/ceramicnetwork/key-did-provider-ed25519)).
+```js
+const { Ed25519Provider } = require('key-did-provider-ed25519')
+const { default: KeyResolver } = require('key-did-resolver')
+const Identities = require('orbit-db-identity-provider')
+Identities.DIDIdentityProvider.setDIDResolver(KeyResolver.getResolver())
+
+const seed = // 32 bytes of entropy (Uint8Array)
+const didProvider = new Ed25519Provider(seed)
+const identity = await Identities.createIdentity({ type: 'DID', didProvider })
+```
+
 ### Create identity using existing keys
 
 To create an identity using existing keys, you need to install `localstorage-level-migration`
@@ -103,7 +116,6 @@ Identities.addIdentityProvider(MyIdentityProvider)
 const identity = await Identities.createIdentity({ type: `MyIdentityType`})
 
 ```
-
 
 ### Properties
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -983,7 +983,6 @@
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
       "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -1027,260 +1026,291 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@ethersproject/abi": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.2.tgz",
-      "integrity": "sha512-Z+5f7xOgtRLu/W2l9Ry5xF7ehh9QVQ0m1vhynmTcS7DMfHgqTd1/PDFC62aw91ZPRCRZsYdZJu8ymokC5e1JSw==",
+    "@ethersproject/wallet": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.10.tgz",
+      "integrity": "sha512-5siYr38NhqZKH6DUr6u4PdhgOKur8Q6sw+JID2TitEUmW0tOl8f6rpxAe77tw6SJT60D2UcvgsyLtl32+Nl+ig==",
       "requires": {
-        "@ethersproject/address": "^5.0.0",
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/constants": "^5.0.0",
-        "@ethersproject/hash": "^5.0.0",
-        "@ethersproject/keccak256": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/strings": "^5.0.0"
-      }
-    },
-    "@ethersproject/abstract-provider": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.2.tgz",
-      "integrity": "sha512-U1s60+nG02x8FKNMoVNI6MG8SguWCoG9HJtwOqWZ38LBRMsDV4c0w4izKx98kcsN3wXw4U2/YAyJ9LlH7+/hkg==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/networks": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/transactions": "^5.0.0",
-        "@ethersproject/web": "^5.0.0"
-      }
-    },
-    "@ethersproject/abstract-signer": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.2.tgz",
-      "integrity": "sha512-CzzXbeqKlgayE4YTnvvreGBG3n+HxakGXrxaGM6LjBZnOOIVSYi6HMFG8ZXls7UspRY4hvMrtnKEJKDCOngSBw==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.0.0",
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0"
-      }
-    },
-    "@ethersproject/address": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.2.tgz",
-      "integrity": "sha512-+rz26RKj7ujGfQynys4V9VJRbR+wpC6eL8F22q3raWMH3152Ha31GwJPWzxE/bEA+43M/zTNVwY0R53gn53L2Q==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/keccak256": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/rlp": "^5.0.0",
-        "bn.js": "^4.4.0"
-      }
-    },
-    "@ethersproject/base64": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.2.tgz",
-      "integrity": "sha512-0FE5RH5cUDddOiQEDpWtyHjkSW4D5/rdJzA3KTZo8Fk5ab/Y8vdzqbamsXPyPsXU3gS+zCE5Qq4EKVOWlWLLTA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.0"
-      }
-    },
-    "@ethersproject/basex": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.2.tgz",
-      "integrity": "sha512-p4m2CeQqI9vma3XipRbP2iDf6zTsbroE0MEXBAYXidsoJQSvePKrC6MVRKfTzfcHej1b9wfmjVBzqhqn3FRhIA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0"
-      }
-    },
-    "@ethersproject/bignumber": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.5.tgz",
-      "integrity": "sha512-24ln7PV0g8ZzjcVZiLW9Wod0i+XCmK6zKkAaxw5enraTIT1p7gVOcSXFSzNQ9WYAwtiFQPvvA+TIO2oEITZNJA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "bn.js": "^4.4.0"
-      }
-    },
-    "@ethersproject/bytes": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.3.tgz",
-      "integrity": "sha512-AyPMAlY+Amaw4Zfp8OAivm1xYPI8mqiUYmEnSUk1CnS2NrQGHEMmFJFiOJdS3gDDpgSOFhWIjZwxKq2VZpqNTA==",
-      "requires": {
-        "@ethersproject/logger": "^5.0.0"
-      }
-    },
-    "@ethersproject/constants": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.2.tgz",
-      "integrity": "sha512-nNoVlNP6bgpog7pQ2EyD1xjlaXcy1Cl4kK5v1KoskHj58EtB6TK8M8AFGi3GgHTdMldfT4eN3OsoQ/CdOTVNFA==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.0.0"
-      }
-    },
-    "@ethersproject/contracts": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.2.tgz",
-      "integrity": "sha512-Ud3oW8mBNIWE+WHRjvwVEwfvshn7lfYWSSKG0fPSb6baRN9mLOoNguX+VIv3W5Sne9w2utnBmxLF2ESXitw64A==",
-      "requires": {
-        "@ethersproject/abi": "^5.0.0",
-        "@ethersproject/abstract-provider": "^5.0.0",
-        "@ethersproject/abstract-signer": "^5.0.0",
-        "@ethersproject/address": "^5.0.0",
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/constants": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0"
-      }
-    },
-    "@ethersproject/hash": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.2.tgz",
-      "integrity": "sha512-dWGvNwmVRX2bxoQQ3ciMw46Vzl1nqfL+5R8+2ZxsRXD3Cjgw1dL2mdjJF7xMMWPvPdrlhKXWSK0gb8VLwHZ8Cw==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/keccak256": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/strings": "^5.0.0"
-      }
-    },
-    "@ethersproject/hdnode": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.2.tgz",
-      "integrity": "sha512-QAUI5tfseTFqv00Vnbwzofqse81wN9TaL+x5GufTHIHJXgVdguxU+l39E3VYDCmO+eVAA6RCn5dJgeyra+PU2g==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.0.0",
-        "@ethersproject/basex": "^5.0.0",
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/pbkdf2": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/sha2": "^5.0.0",
-        "@ethersproject/signing-key": "^5.0.0",
-        "@ethersproject/strings": "^5.0.0",
-        "@ethersproject/transactions": "^5.0.0",
-        "@ethersproject/wordlists": "^5.0.0"
-      }
-    },
-    "@ethersproject/json-wallets": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.4.tgz",
-      "integrity": "sha512-jqtb+X3rJXWG/w+Qyr7vq1V+fdc5jiLlyc6akwI3SQIHTfcuuyF+eZRd9u2/455urNwV3nuCsnrgxs2NrtHHIw==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.0.0",
-        "@ethersproject/address": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/hdnode": "^5.0.0",
-        "@ethersproject/keccak256": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/pbkdf2": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/random": "^5.0.0",
-        "@ethersproject/strings": "^5.0.0",
-        "@ethersproject/transactions": "^5.0.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      }
-    },
-    "@ethersproject/keccak256": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.2.tgz",
-      "integrity": "sha512-MbroXutc0gPNYIrUjS4Aw0lDuXabdzI7+l7elRWr1G6G+W0v00e/3gbikWkCReGtt2Jnt4lQSgnflhDwQGcIhA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "js-sha3": "0.5.7"
-      }
-    },
-    "@ethersproject/logger": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.4.tgz",
-      "integrity": "sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw=="
-    },
-    "@ethersproject/networks": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.2.tgz",
-      "integrity": "sha512-T7HVd62D4izNU2tDHf6xUDo7k4JOGX4Lk7vDmVcDKrepSWwL2OmGWrqSlkRe2a1Dnz4+1VPE6fb6+KsmSRe82g==",
-      "requires": {
-        "@ethersproject/logger": "^5.0.0"
-      }
-    },
-    "@ethersproject/pbkdf2": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.2.tgz",
-      "integrity": "sha512-OJFxdX/VtGI5M04lAzXKEOb76XBzjCOzGyko3/bMWat3ePAw7RveBOLyhm79SBs2fh21MSYgdG6JScEMHoSImw==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/sha2": "^5.0.0"
-      }
-    },
-    "@ethersproject/properties": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.2.tgz",
-      "integrity": "sha512-FxAisPGAOACQjMJzewl9OJG6lsGCPTm5vpUMtfeoxzAlAb2lv+kHzQPUh9h4jfAILzE8AR1jgXMzRmlhwyra1Q==",
-      "requires": {
-        "@ethersproject/logger": "^5.0.0"
-      }
-    },
-    "@ethersproject/providers": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.5.tgz",
-      "integrity": "sha512-ZR3yFg/m8qDl7317yXOHE7tKeGfoyZIZ/imhVC4JqAH+SX1rb6bdZcSjhJfet7rLmnJSsnYLTgIiVIT85aVLgg==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.0.0",
-        "@ethersproject/abstract-signer": "^5.0.0",
-        "@ethersproject/address": "^5.0.0",
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/constants": "^5.0.0",
-        "@ethersproject/hash": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/networks": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/random": "^5.0.0",
-        "@ethersproject/rlp": "^5.0.0",
-        "@ethersproject/strings": "^5.0.0",
-        "@ethersproject/transactions": "^5.0.0",
-        "@ethersproject/web": "^5.0.0",
-        "ws": "7.2.3"
-      }
-    },
-    "@ethersproject/random": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.2.tgz",
-      "integrity": "sha512-kLeS+6bwz37WR2zbe69gudyoGVoUzljQO0LhifnATsZ7rW0JZ9Zgt0h5aXY7tqFDo9TvdqeCwUFdp1t3T5Fkhg==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0"
-      }
-    },
-    "@ethersproject/rlp": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.2.tgz",
-      "integrity": "sha512-oE0M5jqQ67fi2SuMcrpoewOpEuoXaD8M9JeR9md1bXRMvDYgKXUtDHs22oevpEOdnO2DPIRabp6MVHa4aDuWmw==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0"
-      }
-    },
-    "@ethersproject/sha2": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.2.tgz",
-      "integrity": "sha512-VFl4qSStjQZaygpqoAHswaCY59qBm1Sm0rf8iv0tmgVsRf0pBg2nJaNf9NXXvcuJ9AYPyXl57dN8kozdC4z5Cg==",
-      "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "hash.js": "1.1.3"
+        "@ethersproject/abstract-provider": "^5.0.8",
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/hash": "^5.0.10",
+        "@ethersproject/hdnode": "^5.0.8",
+        "@ethersproject/json-wallets": "^5.0.10",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/random": "^5.0.7",
+        "@ethersproject/signing-key": "^5.0.8",
+        "@ethersproject/transactions": "^5.0.9",
+        "@ethersproject/wordlists": "^5.0.8"
       },
       "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
+          "integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/networks": "^5.0.7",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/transactions": "^5.0.9",
+            "@ethersproject/web": "^5.0.12"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.11.tgz",
+          "integrity": "sha512-RKOgPSEYafknA62SrD3OCK42AllHE4YBfKYXyQeM+sBP7Nq3X5FpzeoY4uzC43P4wIhmNoTHCKQuwnX7fBqb6Q==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.0.8",
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
+          "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/rlp": "^5.0.7"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
+          "integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9"
+          }
+        },
+        "@ethersproject/basex": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.7.tgz",
+          "integrity": "sha512-OsXnRsujGmYD9LYyJlX+cVe5KfwgLUbUJrJMWdzRWogrygXd5HvGd7ygX1AYjlu1z8W/+t2FoQnczDR/H2iBjA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/properties": "^5.0.7"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.13",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
+          "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
+          "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
+          "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
+          "integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.10",
+            "@ethersproject/address": "^5.0.9",
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/strings": "^5.0.8"
+          }
+        },
+        "@ethersproject/hdnode": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.8.tgz",
+          "integrity": "sha512-Mscpjd7BBjxYSWghaNMwV0xrBBkOoCq6YEPRm9MgE24CiBlzzbfEB5DGq6hiZqhQaxPkdCUtKKqZi3nt9hx43g==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.10",
+            "@ethersproject/basex": "^5.0.7",
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/pbkdf2": "^5.0.7",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/sha2": "^5.0.7",
+            "@ethersproject/signing-key": "^5.0.8",
+            "@ethersproject/strings": "^5.0.8",
+            "@ethersproject/transactions": "^5.0.9",
+            "@ethersproject/wordlists": "^5.0.8"
+          }
+        },
+        "@ethersproject/json-wallets": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.10.tgz",
+          "integrity": "sha512-Ux36u+d7Dm0M5AQ+mWuHdvfGPMN8K1aaLQgwzrsD4ELTWlwRuHuQbmn7/GqeOpbfaV6POLwdYcBk2TXjlGp/IQ==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.10",
+            "@ethersproject/address": "^5.0.9",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/hdnode": "^5.0.8",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/pbkdf2": "^5.0.7",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/random": "^5.0.7",
+            "@ethersproject/strings": "^5.0.8",
+            "@ethersproject/transactions": "^5.0.9",
+            "aes-js": "3.0.0",
+            "scrypt-js": "3.0.1"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
+          "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
+          "integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/pbkdf2": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.7.tgz",
+          "integrity": "sha512-0SNLNixPMqnosH6pyc4yPiUu/C9/Jbu+f6I8GJW9U2qNpMBddmRJviwseoha5Zw1V+Aw0Z/yvYyzIIE8yPXqLA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/sha2": "^5.0.7"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
+          "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/random": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.7.tgz",
+          "integrity": "sha512-PxSRWwN3s+FH9AWMZU6AcWJsNQ9KzqKV6NgdeKPtxahdDjCuXxTAuzTZNXNRK+qj+Il351UnweAGd+VuZcOAlQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
+          "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/sha2": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.7.tgz",
+          "integrity": "sha512-MbUqz68hhp5RsaZdqi1eg1rrtiqt5wmhRYqdA7MX8swBkzW2KiLgK+Oh25UcWhUhdi1ImU9qrV6if5j0cC7Bxg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "hash.js": "1.1.3"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
+          "integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "elliptic": "6.5.3"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
+          "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/constants": "^5.0.8",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
+          "integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.9",
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/constants": "^5.0.8",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/rlp": "^5.0.7",
+            "@ethersproject/signing-key": "^5.0.8"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.0.12",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
+          "integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
+          "requires": {
+            "@ethersproject/base64": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/strings": "^5.0.8"
+          }
+        },
+        "@ethersproject/wordlists": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.8.tgz",
+          "integrity": "sha512-px2mloc1wAcdTbzv0ZotTx+Uh/dfnDO22D9Rx8xr7+/PUwAhZQjoJ9t7Hn72nsaN83rWBXsLvFcIRZju4GIaEQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/hash": "^5.0.10",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/strings": "^5.0.8"
+          }
+        },
         "hash.js": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
@@ -1292,109 +1322,157 @@
         }
       }
     },
-    "@ethersproject/signing-key": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.3.tgz",
-      "integrity": "sha512-5QPZaBRGCLzfVMbFb3LcVjNR0UbTXnwDHASnQYfbzwUOnFYHKxHsrcbl/5ONGoppgi8yXgOocKqlPCFycJJVWQ==",
+    "@multiformats/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
+    "@stablelib/aead": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.0.tgz",
+      "integrity": "sha512-2iO0P15w1onK8g/m6ygNqlMFBfC7BM8o1Zr7jRqMAF9+zhhyY3h4NZwnXKxUm11TBm62Yeesw+FKqs/gJ6shMA=="
+    },
+    "@stablelib/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "elliptic": "6.5.3"
+        "@stablelib/int": "^1.0.0"
       }
     },
-    "@ethersproject/solidity": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.2.tgz",
-      "integrity": "sha512-RygurUe1hPW1LDYAPXy4471AklGWNnxgFWc3YUE6H11gzkit26jr6AyZH4Yyjw38eBBL6j0AOfQzMWm+NhxZ9g==",
+    "@stablelib/bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.0.tgz",
+      "integrity": "sha512-c9CfJwoZpxub6yicmhkeEpvLLsvsAP76tBAHEXKuEjPzza946U7bgebJJoMl8Q+ZlU2vy9ZoWCXE1uLpi817Pg=="
+    },
+    "@stablelib/chacha": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.0.tgz",
+      "integrity": "sha512-tlp3ECXiU7APq6n1YQ2K4B7MUppAOUWsvN1JMs2OWnYVR2Km+AsSmgMjjtefG8vPZ+J8tfY3sufzh5zCg5xiSw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/keccak256": "^5.0.0",
-        "@ethersproject/sha2": "^5.0.0",
-        "@ethersproject/strings": "^5.0.0"
+        "@stablelib/binary": "^1.0.0",
+        "@stablelib/wipe": "^1.0.0"
       }
     },
-    "@ethersproject/strings": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.2.tgz",
-      "integrity": "sha512-oNa+xvSqsFU96ndzog0IBTtsRFGOqGpzrXJ7shXLBT7juVeSEyZA/sYs0DMZB5mJ9FEjHdZKxR/rTyBY91vuXg==",
+    "@stablelib/chacha20poly1305": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.0.tgz",
+      "integrity": "sha512-sRv7T5nDRpwqerY9VZ3ABfzHukF/aa2njKvCHPvMpM3+WOYqU4JIP47MdvmrEj+NFHFP3hBx6XV5xpnV8IqMig==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/constants": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0"
+        "@stablelib/aead": "^1.0.0",
+        "@stablelib/binary": "^1.0.0",
+        "@stablelib/chacha": "^1.0.0",
+        "@stablelib/constant-time": "^1.0.0",
+        "@stablelib/poly1305": "^1.0.0",
+        "@stablelib/wipe": "^1.0.0"
       }
     },
-    "@ethersproject/transactions": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.2.tgz",
-      "integrity": "sha512-jZp0ZbbJlq4JLZY6qoMzNtp2HQsX6USQposi3ns0MPUdn3OdZJBDtrcO15r/2VS5t/K1e1GE5MI1HmMKlcTbbQ==",
+    "@stablelib/constant-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.0.tgz",
+      "integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA=="
+    },
+    "@stablelib/ed25519": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.1.tgz",
+      "integrity": "sha512-kvC98vkJeertRj37yqTcjOwUVYWQ0jcywxxWpeuTal5ZNgH7EcbljtQYECA2Pi2N0zNG0a0AjSD2Q2DFcUxRjQ==",
       "requires": {
-        "@ethersproject/address": "^5.0.0",
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/constants": "^5.0.0",
-        "@ethersproject/keccak256": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/rlp": "^5.0.0",
-        "@ethersproject/signing-key": "^5.0.0"
+        "@stablelib/random": "^1.0.0",
+        "@stablelib/sha512": "^1.0.0",
+        "@stablelib/wipe": "^1.0.0"
       }
     },
-    "@ethersproject/units": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.2.tgz",
-      "integrity": "sha512-PSuzycBA1zmRysTtKtp+XYZ3HIJfbmfRdZchOUxdyeGo5siUi9H6mYQcxdJHv82oKp/FniMj8qS8qtLQThhOEg==",
+    "@stablelib/hash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.0.tgz",
+      "integrity": "sha512-wBvSIIx4Y8799BRD4TBhezS1P9+irGAKdsNgbZMeU5ndMbw7BtZALdCm0FcJIRFxJ2giPLPS9YCgrwWAhzSRLQ=="
+    },
+    "@stablelib/int": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
+      "integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA=="
+    },
+    "@stablelib/keyagreement": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.0.tgz",
+      "integrity": "sha512-M4f0QhuYGrMCLPoJIKWpC5riJfDivOFZHOAlj1Av44UJSyMzM46gJW0e9khKoTcbU8r8oXebkwlJT70Xm0+kqg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/constants": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0"
+        "@stablelib/bytes": "^1.0.0"
       }
     },
-    "@ethersproject/wallet": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.2.tgz",
-      "integrity": "sha512-gg86ynLV5k5caNnYpJoYc6WyIUHKMTjOITCk5zXGyVbbkXE07y/fGql4A51W0C6mWkeb5Mzz8AKqzHZECdH30w==",
+    "@stablelib/poly1305": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.0.tgz",
+      "integrity": "sha512-8EOq8g3Naae+gGI/c/Tt1+xhbgDvkFwYx7QfTlps7SwA/IC6dhEZ+BzvU6O9FuVQ/l72yV7i3PSJ3LMOvTxS8g==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.0",
-        "@ethersproject/abstract-signer": "^5.0.0",
-        "@ethersproject/address": "^5.0.0",
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/hash": "^5.0.0",
-        "@ethersproject/hdnode": "^5.0.0",
-        "@ethersproject/json-wallets": "^5.0.0",
-        "@ethersproject/keccak256": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/random": "^5.0.0",
-        "@ethersproject/signing-key": "^5.0.0",
-        "@ethersproject/transactions": "^5.0.0",
-        "@ethersproject/wordlists": "^5.0.0"
+        "@stablelib/constant-time": "^1.0.0",
+        "@stablelib/wipe": "^1.0.0"
       }
     },
-    "@ethersproject/web": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.3.tgz",
-      "integrity": "sha512-9WoIWNxbFOk+8TiWqQMQbYJUIFeC1Z7zNr7oCHpVyhxF0EY54ZVXlP/Y7VJ7KzK++A/iMGOuTIGeL5sMqa2QMg==",
+    "@stablelib/random": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.0.tgz",
+      "integrity": "sha512-G9vwwKrNCGMI/uHL6XeWe2Nk4BuxkYyWZagGaDU9wrsuV+9hUwNI1lok2WVo8uJDa2zx7ahNwN7Ij983hOUFEw==",
       "requires": {
-        "@ethersproject/base64": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/strings": "^5.0.0"
+        "@stablelib/binary": "^1.0.0",
+        "@stablelib/wipe": "^1.0.0"
       }
     },
-    "@ethersproject/wordlists": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.2.tgz",
-      "integrity": "sha512-6vKDQcjjpnfdSCr0+jNxpFH3ieKxUPkm29tQX2US7a3zT/sJU/BGlKBR7D8oOpwdE0hpkHhJyMlypRBK+A2avA==",
+    "@stablelib/sha256": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.0.tgz",
+      "integrity": "sha512-+IEzCXO6HSyYWV+5TqdFjcUYgkebdiadzRtMXJg6ia68WQm2xHpABl5t0vVdtvgTlw7matBRhImunAHUFIAEUg==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/hash": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/strings": "^5.0.0"
+        "@stablelib/binary": "^1.0.0",
+        "@stablelib/hash": "^1.0.0",
+        "@stablelib/wipe": "^1.0.0"
+      }
+    },
+    "@stablelib/sha512": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.0.tgz",
+      "integrity": "sha512-qvUu5SraAdGa8HAkAasfMyD9C+MwlRnFVRJ6cRxAEIekmDsU3tfGLnUm3wb9ao4t0FkihGrj8GKlV82TTR4Phw==",
+      "requires": {
+        "@stablelib/binary": "^1.0.0",
+        "@stablelib/hash": "^1.0.0",
+        "@stablelib/wipe": "^1.0.0"
+      }
+    },
+    "@stablelib/wipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
+      "integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
+    },
+    "@stablelib/x25519": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.0.tgz",
+      "integrity": "sha512-sjlOzC8eZJhHTuMZnSTxtawYXbFXZtHm6TbhacvoYmJOG9/3cFX5z1Aw0WZfQvPNSk+8aPrpwuyRMmUO1PW8yw==",
+      "requires": {
+        "@stablelib/keyagreement": "^1.0.0",
+        "@stablelib/random": "^1.0.0",
+        "@stablelib/wipe": "^1.0.0"
+      }
+    },
+    "@stablelib/xchacha20": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/xchacha20/-/xchacha20-1.0.0.tgz",
+      "integrity": "sha512-8q98HxPCgVUGMnjMl79KhEtWsh0UQbTt5x1570QnynF3uzzsGgP7exXwkyqi7s85SdvdO8EKEezDMjuzqv69Yw==",
+      "requires": {
+        "@stablelib/binary": "^1.0.0",
+        "@stablelib/chacha": "^1.0.0",
+        "@stablelib/wipe": "^1.0.0"
+      }
+    },
+    "@stablelib/xchacha20poly1305": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/xchacha20poly1305/-/xchacha20poly1305-1.0.0.tgz",
+      "integrity": "sha512-rVcKmgEeMK8kInx2bvvBXLL/wMKrqeA6luWiZYRQj1QMnZnq3ReZd1szZdz2QWFQOlp7rXsZp+EaM4FqNlfZSw==",
+      "requires": {
+        "@stablelib/aead": "^1.0.0",
+        "@stablelib/chacha20poly1305": "^1.0.0",
+        "@stablelib/constant-time": "^1.0.0",
+        "@stablelib/wipe": "^1.0.0",
+        "@stablelib/xchacha20": "^1.0.0"
       }
     },
     "@types/json-schema": {
@@ -1941,6 +2019,11 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
     },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -1979,6 +2062,20 @@
       "version": "4.11.9",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
       "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+    },
+    "borc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "buffer": "^5.5.0",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.13",
+        "iso-url": "~0.4.7",
+        "json-text-sequence": "~0.1.0",
+        "readable-stream": "^3.6.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2324,6 +2421,52 @@
         "tslib": "^1.9.0"
       }
     },
+    "cids": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.5.tgz",
+      "integrity": "sha512-i0V7tF2Jf78BKXyy2rpy1H/ozaJEP8b3Z7ZcHe9J86RRvJZ4e7daaJP3xwL09e14/Bl/mYX5WVc36fbQtjH7Sg==",
+      "requires": {
+        "multibase": "^3.0.1",
+        "multicodec": "^2.1.0",
+        "multihashes": "^3.1.0",
+        "uint8arrays": "^2.0.5"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.1.tgz",
+          "integrity": "sha512-kkSd8jWGznDNEC2eDwtnvSGlZeTeEt0+oHieNWUhv8rIi8JU3voIUo02HpJBNOtgmtxT2CPwkElub7Y9kz3nrw==",
+          "requires": {
+            "@multiformats/base-x": "^4.0.1",
+            "web-encoding": "^1.0.6"
+          }
+        },
+        "multihashes": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.1.1.tgz",
+          "integrity": "sha512-oF4BesRWbr5BbcRr1/QCDlZK+An8LWBPHVPYKt/foDpqNtXX/l0lm/rmAjI8dDYruPO90OaGcAWI3KS5vNJdNw==",
+          "requires": {
+            "multibase": "^3.1.0",
+            "uint8arrays": "^2.0.5",
+            "varint": "^6.0.0"
+          }
+        },
+        "uint8arrays": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.0.5.tgz",
+          "integrity": "sha512-1HSktgwqtYIwVn1mg3GcnqKhHH9oC4kVgdD/43cxMWwhP8rihKcFPmToDzS1XtbvVvlR8XxTk/DUBf0C83qNIg==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.5"
+          }
+        },
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        }
+      }
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -2423,8 +2566,7 @@
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -2640,6 +2782,55 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
+    "dag-jose-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dag-jose-utils/-/dag-jose-utils-0.1.0.tgz",
+      "integrity": "sha512-Fs1ElQB1TJ/dEKmryS1AUjBKioOA6RuXzTMGO7hN9Ey2q+E10Z6eA6sbCNdLYOHNxmjKo3yWoEc30IfAZmlXGA==",
+      "requires": {
+        "cids": "^1.0.1",
+        "ipld-dag-cbor": "^0.17.0",
+        "multihashes": "^3.0.1",
+        "uint8arrays": "^1.1.0",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.1.tgz",
+          "integrity": "sha512-kkSd8jWGznDNEC2eDwtnvSGlZeTeEt0+oHieNWUhv8rIi8JU3voIUo02HpJBNOtgmtxT2CPwkElub7Y9kz3nrw==",
+          "requires": {
+            "@multiformats/base-x": "^4.0.1",
+            "web-encoding": "^1.0.6"
+          }
+        },
+        "multihashes": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.1.1.tgz",
+          "integrity": "sha512-oF4BesRWbr5BbcRr1/QCDlZK+An8LWBPHVPYKt/foDpqNtXX/l0lm/rmAjI8dDYruPO90OaGcAWI3KS5vNJdNw==",
+          "requires": {
+            "multibase": "^3.1.0",
+            "uint8arrays": "^2.0.5",
+            "varint": "^6.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.0.5.tgz",
+              "integrity": "sha512-1HSktgwqtYIwVn1mg3GcnqKhHH9oC4kVgdD/43cxMWwhP8rihKcFPmToDzS1XtbvVvlR8XxTk/DUBf0C83qNIg==",
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.5"
+              }
+            }
+          }
+        },
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        }
+      }
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -2768,6 +2959,11 @@
         }
       }
     },
+    "delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -2783,6 +2979,67 @@
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
+    },
+    "did-jwt": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.8.1.tgz",
+      "integrity": "sha512-TRfk6He4MSUe3mN+YBqX4wC8N4ns3jan0Ckwal6fPsexKYRwo20ns8w0IGt7J4oHOF3IxXNAkH07OBdEpMnEdA==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "@stablelib/ed25519": "^1.0.1",
+        "@stablelib/random": "^1.0.0",
+        "@stablelib/sha256": "^1.0.0",
+        "@stablelib/x25519": "^1.0.0",
+        "@stablelib/xchacha20poly1305": "^1.0.0",
+        "did-resolver": "^2.1.2",
+        "elliptic": "^6.5.3",
+        "js-sha3": "^0.8.0",
+        "uint8arrays": "^2.0.0"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "multibase": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.1.tgz",
+          "integrity": "sha512-kkSd8jWGznDNEC2eDwtnvSGlZeTeEt0+oHieNWUhv8rIi8JU3voIUo02HpJBNOtgmtxT2CPwkElub7Y9kz3nrw==",
+          "requires": {
+            "@multiformats/base-x": "^4.0.1",
+            "web-encoding": "^1.0.6"
+          }
+        },
+        "uint8arrays": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.0.5.tgz",
+          "integrity": "sha512-1HSktgwqtYIwVn1mg3GcnqKhHH9oC4kVgdD/43cxMWwhP8rihKcFPmToDzS1XtbvVvlR8XxTk/DUBf0C83qNIg==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.5"
+          }
+        }
+      }
+    },
+    "did-resolver": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.1.2.tgz",
+      "integrity": "sha512-n4YGS1CzbX48U/ChLRY3SdgiV5N3B/+yh0ToS5t+Sx4QjhVZN6ZyijUSSYbFGvz+I4qImeSZOdo6RX8JaieN7A=="
+    },
+    "dids": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dids/-/dids-1.1.1.tgz",
+      "integrity": "sha512-4xm1ku1s5OZE2lFi2/521rIE3CHI3RgnA2uCnzcbvvnYq3nxlPPW97aSH4LWyul8jYxTuB566ZKesdU1Ol6sew==",
+      "requires": {
+        "@stablelib/random": "^1.0.0",
+        "cids": "^1.0.0",
+        "dag-jose-utils": "^0.1.0",
+        "did-jwt": "^4.8.0",
+        "did-resolver": "^2.1.2",
+        "rpc-utils": "^0.1.3",
+        "uint8arrays": "^1.1.0"
+      }
     },
     "diff": {
       "version": "3.5.0",
@@ -2988,6 +3245,11 @@
           }
         }
       }
+    },
+    "err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "errno": {
       "version": "0.1.7",
@@ -3437,43 +3699,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
-    },
-    "ethers": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.8.tgz",
-      "integrity": "sha512-of/rPgJ7E3yyBADUv5A7Gtkd7EB8ta/T9NS5CCG9tj9cifnXcI3KIdYQ7d8AS+9vm38pR1g6S5I+Q/mRnlQZlg==",
-      "requires": {
-        "@ethersproject/abi": "^5.0.0",
-        "@ethersproject/abstract-provider": "^5.0.0",
-        "@ethersproject/abstract-signer": "^5.0.0",
-        "@ethersproject/address": "^5.0.0",
-        "@ethersproject/base64": "^5.0.0",
-        "@ethersproject/basex": "^5.0.0",
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/constants": "^5.0.0",
-        "@ethersproject/contracts": "^5.0.0",
-        "@ethersproject/hash": "^5.0.0",
-        "@ethersproject/hdnode": "^5.0.0",
-        "@ethersproject/json-wallets": "^5.0.0",
-        "@ethersproject/keccak256": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/networks": "^5.0.0",
-        "@ethersproject/pbkdf2": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/providers": "^5.0.0",
-        "@ethersproject/random": "^5.0.0",
-        "@ethersproject/rlp": "^5.0.0",
-        "@ethersproject/sha2": "^5.0.0",
-        "@ethersproject/signing-key": "^5.0.0",
-        "@ethersproject/solidity": "^5.0.0",
-        "@ethersproject/strings": "^5.0.0",
-        "@ethersproject/transactions": "^5.0.0",
-        "@ethersproject/units": "^5.0.0",
-        "@ethersproject/wallet": "^5.0.0",
-        "@ethersproject/web": "^5.0.0",
-        "@ethersproject/wordlists": "^5.0.0"
-      }
     },
     "events": {
       "version": "3.2.0",
@@ -4363,6 +4588,74 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "ipld-dag-cbor": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.17.0.tgz",
+      "integrity": "sha512-YprSTQClJQUyC+RhbWrVXhg7ysII5R/jrmZZ4en4n9Mav+MRbntAW699zd1PHRLB71lNCJbxABE2Uc9QU2Ka7g==",
+      "requires": {
+        "borc": "^2.1.2",
+        "cids": "^1.0.0",
+        "is-circular": "^1.0.2",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0",
+        "uint8arrays": "^1.0.0"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "multibase": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.1.tgz",
+          "integrity": "sha512-kkSd8jWGznDNEC2eDwtnvSGlZeTeEt0+oHieNWUhv8rIi8JU3voIUo02HpJBNOtgmtxT2CPwkElub7Y9kz3nrw==",
+          "requires": {
+            "@multiformats/base-x": "^4.0.1",
+            "web-encoding": "^1.0.6"
+          }
+        },
+        "multihashes": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.1.1.tgz",
+          "integrity": "sha512-oF4BesRWbr5BbcRr1/QCDlZK+An8LWBPHVPYKt/foDpqNtXX/l0lm/rmAjI8dDYruPO90OaGcAWI3KS5vNJdNw==",
+          "requires": {
+            "multibase": "^3.1.0",
+            "uint8arrays": "^2.0.5",
+            "varint": "^6.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.0.5.tgz",
+              "integrity": "sha512-1HSktgwqtYIwVn1mg3GcnqKhHH9oC4kVgdD/43cxMWwhP8rihKcFPmToDzS1XtbvVvlR8XxTk/DUBf0C83qNIg==",
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.5"
+              }
+            }
+          }
+        },
+        "multihashing-async": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.0.1.tgz",
+          "integrity": "sha512-LZcH8PqW4iEKymaJ3RpsgpSJhXF29kAvO02ccqbysiXkQhZpVce8rrg+vzRKWO89hhyIBnQHI2e/ZoRVxmiJ2Q==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^3.0.1",
+            "murmurhash3js-revisited": "^3.0.0",
+            "uint8arrays": "^1.0.0"
+          }
+        },
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        }
+      }
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -4410,6 +4703,11 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
       "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
+    },
+    "is-circular": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
+      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -4585,6 +4883,11 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "iso-url": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
+    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -4642,6 +4945,14 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "requires": {
+        "delimit-stream": "0.1.0"
+      }
+    },
     "json5": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -4668,6 +4979,49 @@
       "requires": {
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.0"
+      }
+    },
+    "key-did-provider-ed25519": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-1.0.0.tgz",
+      "integrity": "sha512-EBjhh+Rnyzfpb8GAUgILq8AflDaPmS6eE3vQTtHZgIKJ7wd4p3wSLEZr0QE2AY3h/1KDNbAM3v9IZgZd57urfg==",
+      "dev": true,
+      "requires": {
+        "@stablelib/ed25519": "^1.0.1",
+        "did-jwt": "^4.6.3",
+        "fast-json-stable-stringify": "^2.1.0",
+        "rpc-utils": "^0.1.3",
+        "uint8arrays": "^1.1.0"
+      }
+    },
+    "key-did-resolver": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-0.2.4.tgz",
+      "integrity": "sha512-/dtq2eHKavlPZKpx5vdBW+vHN7nY4kMCAlg1FzeNqwLT9kYvuQQezSZgW6DDJDR2QZUaHT9MG4dvB8K18wj+6A==",
+      "dev": true,
+      "requires": {
+        "@stablelib/ed25519": "^1.0.1",
+        "multibase": "3.0.1",
+        "uint8arrays": "^1.1.0",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
+          "integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
+          "dev": true,
+          "requires": {
+            "@multiformats/base-x": "^4.0.1",
+            "web-encoding": "^1.0.2"
+          }
+        },
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+          "dev": true
+        }
       }
     },
     "keypair": {
@@ -5280,6 +5634,22 @@
         "buffer": "^5.5.0"
       }
     },
+    "multicodec": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.1.0.tgz",
+      "integrity": "sha512-7AYpK/avswOWvnqQ9/jOkQCS7Fp4aKxw5ojvn5gyK2VQTZz3YVXeLMzoIZDBy745JSfJMXkTS0ptnHci5Mt1mA==",
+      "requires": {
+        "uint8arrays": "1.1.0",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        }
+      }
+    },
     "multihashes": {
       "version": "0.4.21",
       "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
@@ -5314,6 +5684,11 @@
       "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
       "integrity": "sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg="
     },
+    "murmurhash3js-revisited": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
+      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -5324,6 +5699,11 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+    },
+    "nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -6278,8 +6658,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -6483,6 +6862,14 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "rpc-utils": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/rpc-utils/-/rpc-utils-0.1.3.tgz",
+      "integrity": "sha512-7KRen4ydhnH5aCduhoCOKXCSjutVVEXTHFi6k/8BMnVOuhLbGa5vHJncfYTRtzQSQT4fUB39lVAs1MppONLLtQ==",
+      "requires": {
+        "nanoid": "^3.1.12"
       }
     },
     "rsa-pem-to-jwk": {
@@ -7418,6 +7805,26 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "uint8arrays": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+      "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+      "requires": {
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.2"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.1.tgz",
+          "integrity": "sha512-kkSd8jWGznDNEC2eDwtnvSGlZeTeEt0+oHieNWUhv8rIi8JU3voIUo02HpJBNOtgmtxT2CPwkElub7Y9kz3nrw==",
+          "requires": {
+            "@multiformats/base-x": "^4.0.1",
+            "web-encoding": "^1.0.6"
+          }
+        }
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -7796,6 +8203,11 @@
         }
       }
     },
+    "web-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.6.tgz",
+      "integrity": "sha512-26wEnRPEFAc5d5lmH1Q/DuvWEYsRF1D2alX2jlKpdmqv7cj+BbANL7Xlcl9r4s72Eg9kItZa9RWVbBMC9dMv4w=="
+    },
     "webpack": {
       "version": "4.44.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
@@ -7988,11 +8400,6 @@
         "imurmurhash": "^0.1.4",
         "slide": "^1.1.5"
       }
-    },
-    "ws": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "fs-extra": "^7.0.1",
     "is-node": "^1.0.2",
     "json-loader": "^0.5.7",
+    "key-did-provider-ed25519": "^1.0.0",
+    "key-did-resolver": "^0.2.4",
     "localstorage-level-migration": "~0.1.0",
     "mocha": "^5.2.0",
     "mocha-headless-chrome": "^2.0.3",
@@ -59,7 +61,8 @@
     ]
   },
   "dependencies": {
-    "ethers": "^5.0.8",
+    "@ethersproject/wallet": "^5.0.10",
+    "dids": "^1.1.1",
     "orbit-db-keystore": "~0.3.5"
   },
   "localMaintainers": [

--- a/src/did-identity-provider.js
+++ b/src/did-identity-provider.js
@@ -1,0 +1,59 @@
+'use strict'
+const IdentityProvider = require('./identity-provider-interface')
+const u8a = require('uint8arrays')
+const { DID } = require('dids')
+
+const TYPE = 'DID'
+
+class DIDIdentityProvider extends IdentityProvider {
+  constructor ({ didProvider }) {
+    super()
+    this.did = new DID({
+      resolver: DIDIdentityProvider.did._resolver,
+      provider: didProvider
+    })
+  }
+
+  static get type () {
+    return TYPE
+  }
+
+  async getId ({ space }) {
+    if (!this.did.authenticated) await this.did.authenticate()
+    return this.did.id
+  }
+
+  async signIdentity (data, { space }) {
+    if (!this.did.authenticated) await this.did.authenticate()
+    const payload = u8a.toString(u8a.fromString(data, 'base16'), 'base64url')
+    const jws = await this.did.createJWS(payload)
+    // encode as JWS with detached payload
+    return `${jws.signatures[0].protected}..${jws.signatures[0].signature}`
+  }
+
+  static async setDidResolver(resolver) {
+    if (!this.did) {
+      this.did = new DID({ resolver })
+    } else {
+      this.did.setResolver(resolver)
+    }
+  }
+
+  static async verifyIdentity (identity) {
+    if (!this.did) {
+      throw new Error('The DID resolver must first be set with setDidResolver()')
+    }
+    const data = identity.publicKey + identity.signatures.id
+    try {
+      const payload = u8a.toString(u8a.fromString(data, 'base16'), 'base64url')
+      const [header, signature] = identity.signatures.publicKey.split('..')
+      const jws = [header, payload, signature].join('.')
+      await this.did.verifyJWS(jws)
+    } catch (e) {
+      return false
+    }
+    return true
+   }
+}
+
+module.exports = DIDIdentityProvider

--- a/src/did-identity-provider.js
+++ b/src/did-identity-provider.js
@@ -31,7 +31,7 @@ class DIDIdentityProvider extends IdentityProvider {
     return `${jws.signatures[0].protected}..${jws.signatures[0].signature}`
   }
 
-  static setDIDResolver(resolver) {
+  static setDIDResolver (resolver) {
     if (!this.did) {
       this.did = new DID({ resolver })
     } else {
@@ -53,7 +53,7 @@ class DIDIdentityProvider extends IdentityProvider {
       return false
     }
     return true
-   }
+  }
 }
 
 module.exports = DIDIdentityProvider

--- a/src/did-identity-provider.js
+++ b/src/did-identity-provider.js
@@ -31,7 +31,7 @@ class DIDIdentityProvider extends IdentityProvider {
     return `${jws.signatures[0].protected}..${jws.signatures[0].signature}`
   }
 
-  static async setDidResolver(resolver) {
+  static setDIDResolver(resolver) {
     if (!this.did) {
       this.did = new DID({ resolver })
     } else {
@@ -41,7 +41,7 @@ class DIDIdentityProvider extends IdentityProvider {
 
   static async verifyIdentity (identity) {
     if (!this.did) {
-      throw new Error('The DID resolver must first be set with setDidResolver()')
+      throw new Error('The DID resolver must first be set with setDIDResolver()')
     }
     const data = identity.publicKey + identity.signatures.id
     try {

--- a/src/ethereum-identity-provider.js
+++ b/src/ethereum-identity-provider.js
@@ -1,6 +1,6 @@
 'use strict'
 const IdentityProvider = require('./identity-provider-interface')
-const { Wallet, utils } = require('ethers')
+const { Wallet, verifyMessage } = require('@ethersproject/wallet')
 const type = 'ethereum'
 
 class EthIdentityProvider extends IdentityProvider {
@@ -30,7 +30,7 @@ class EthIdentityProvider extends IdentityProvider {
 
   static async verifyIdentity (identity) {
     // Verify that identity was signed by the id
-    const signerAddress = utils.verifyMessage(identity.publicKey + identity.signatures.id, identity.signatures.publicKey)
+    const signerAddress = verifyMessage(identity.publicKey + identity.signatures.id, identity.signatures.publicKey)
     return (signerAddress === identity.id)
   }
 

--- a/src/identities.js
+++ b/src/identities.js
@@ -2,6 +2,8 @@
 const Identity = require('./identity')
 const IdentityProvider = require('./identity-provider-interface.js')
 const OrbitDBIdentityProvider = require('./orbit-db-identity-provider')
+const DIDIdentityProvider = require('./did-identity-provider')
+const EthIdentityProvider = require('./ethereum-identity-provider')
 const Keystore = require('orbit-db-keystore')
 
 const LRU = require('lru')
@@ -11,7 +13,9 @@ const defaultType = 'orbitdb'
 const identityKeysPath = path.join('./orbitdb', 'identity', 'identitykeys')
 
 const supportedTypes = {
-  orbitdb: OrbitDBIdentityProvider
+  orbitdb: OrbitDBIdentityProvider,
+  [DIDIdentityProvider.type]: DIDIdentityProvider,
+  [EthIdentityProvider.type]: EthIdentityProvider
 }
 
 const getHandlerFor = (type) => {
@@ -154,3 +158,5 @@ class Identities {
 }
 
 module.exports = Identities
+module.exports.DIDIdentityProvider = DIDIdentityProvider
+module.exports.EthIdentityProvider = EthIdentityProvider

--- a/test/did-identity-provider.spec.js
+++ b/test/did-identity-provider.spec.js
@@ -1,0 +1,144 @@
+'use strict'
+
+const assert = require('assert')
+const path = require('path')
+const rmrf = require('rimraf')
+const u8a = require('uint8arrays')
+const { Ed25519Provider } = require('key-did-provider-ed25519')
+const { default: KeyResolver } = require('key-did-resolver')
+const Keystore = require('orbit-db-keystore')
+const Identities = require('../src/identities')
+const DIDIdentityProvider = require('../src/did-identity-provider')
+const Identity = require('../src/identity')
+const keypath = path.resolve('./test/keys')
+let keystore
+
+const seed = new Uint8Array([ 157, 94, 116, 198, 19, 248, 93, 239, 173, 82, 245, 222, 199, 7, 183, 177, 123, 238, 83, 240, 143, 188, 87, 191, 33, 95, 58, 136, 46, 218, 219, 245 ])
+const didStr = 'did:key:z6MkpnTJwrrVuphNh1uKb5DB7eRxvqniVaSDUHU6jtGVmn3r'
+
+const type = DIDIdentityProvider.type
+describe('DID Identity Provider', function () {
+  before(async () => {
+    rmrf.sync(keypath)
+    DIDIdentityProvider.setDidResolver(KeyResolver.getResolver())
+    Identities.addIdentityProvider(DIDIdentityProvider)
+    keystore = new Keystore(keypath)
+  })
+
+  after(async () => {
+    await keystore.close()
+    rmrf.sync(keypath)
+  })
+
+  describe('create an DID identity', () => {
+    let identity
+    let wallet
+
+    before(async () => {
+      const didProvider = new Ed25519Provider(seed)
+      identity = await Identities.createIdentity({ type, keystore, didProvider })
+    })
+
+    it('has the correct id', async () => {
+      assert.strictEqual(identity.id, didStr)
+    })
+
+    it('created a key for id in keystore', async () => {
+      const key = await keystore.getKey(didStr)
+      assert.notStrictEqual(key, undefined)
+    })
+
+    it('has the correct public key', async () => {
+      const signingKey = await keystore.getKey(didStr)
+      assert.notStrictEqual(signingKey, undefined)
+      assert.strictEqual(identity.publicKey, keystore.getPublic(signingKey))
+    })
+
+    it('has a signature for the id', async () => {
+      const signingKey = await keystore.getKey(didStr)
+      const idSignature = await keystore.sign(signingKey, didStr)
+      const verifies = await Keystore.verify(idSignature, identity.publicKey, didStr)
+      assert.strictEqual(verifies, true)
+      assert.strictEqual(identity.signatures.id, idSignature)
+    })
+
+    it('has a signature for the publicKey', async () => {
+      const signingKey = await keystore.getKey(didStr)
+      const idSignature = await keystore.sign(signingKey, didStr)
+      assert.notStrictEqual(identity.signatures.publicKey, undefined)
+    })
+  })
+
+  describe('verify identity', () => {
+    let identity
+
+    before(async () => {
+      const didProvider = new Ed25519Provider(seed)
+      identity = await Identities.createIdentity({ type, keystore, didProvider })
+    })
+
+    it('DID identity verifies', async () => {
+      const verified = await Identities.verifyIdentity(identity)
+      assert.strictEqual(verified, true)
+    })
+
+    it('DID identity with incorrect id does not verify', async () => {
+      const identity2 = new Identity('NotAnId', identity.publicKey, identity.signatures.id, identity.signatures.publicKey, identity.type, identity.provider)
+      const verified = await Identities.verifyIdentity(identity2)
+      assert.strictEqual(verified, false)
+    })
+  })
+
+  describe('sign data with an identity', () => {
+    let identity
+    const data = 'hello friend'
+
+    before(async () => {
+      const didProvider = new Ed25519Provider(seed)
+      identity = await Identities.createIdentity({ type, keystore, didProvider })
+    })
+
+    it('sign data', async () => {
+      const signingKey = await keystore.getKey(identity.id)
+      const expectedSignature = await keystore.sign(signingKey, data)
+      const signature = await identity.provider.sign(identity, data, keystore)
+      assert.strictEqual(signature, expectedSignature)
+    })
+
+    it('throws an error if private key is not found from keystore', async () => {
+      // Remove the key from the keystore (we're using a mock storage in these tests)
+      const modifiedIdentity = new Identity('this id does not exist', identity.publicKey, '<sig>', identity.signatures, identity.type, identity.provider)
+      let signature
+      let err
+      try {
+        signature = await identity.provider.sign(modifiedIdentity, data, keystore)
+      } catch (e) {
+        err = e.toString()
+      }
+      assert.strictEqual(signature, undefined)
+      assert.strictEqual(err, `Error: Private signing key not found from Keystore`)
+    })
+
+    describe('verify data signed by an identity', () => {
+      const data = 'hello friend'
+      let identity
+      let signature
+
+      before(async () => {
+        const didProvider = new Ed25519Provider(seed)
+        identity = await Identities.createIdentity({ type, keystore, didProvider })
+        signature = await identity.provider.sign(identity, data, keystore)
+      })
+
+      it('verifies that the signature is valid', async () => {
+        const verified = await identity.provider.verify(signature, identity.publicKey, data)
+        assert.strictEqual(verified, true)
+      })
+
+      it('doesn\'t verify invalid signature', async () => {
+        const verified = await identity.provider.verify('invalid', identity.publicKey, data)
+        assert.strictEqual(verified, false)
+      })
+    })
+  })
+})

--- a/test/did-identity-provider.spec.js
+++ b/test/did-identity-provider.spec.js
@@ -20,7 +20,7 @@ const type = DIDIdentityProvider.type
 describe('DID Identity Provider', function () {
   before(async () => {
     rmrf.sync(keypath)
-    DIDIdentityProvider.setDidResolver(KeyResolver.getResolver())
+    DIDIdentityProvider.setDIDResolver(KeyResolver.getResolver())
     Identities.addIdentityProvider(DIDIdentityProvider)
     keystore = new Keystore(keypath)
   })

--- a/test/did-identity-provider.spec.js
+++ b/test/did-identity-provider.spec.js
@@ -3,7 +3,6 @@
 const assert = require('assert')
 const path = require('path')
 const rmrf = require('rimraf')
-const u8a = require('uint8arrays')
 const { Ed25519Provider } = require('key-did-provider-ed25519')
 const { default: KeyResolver } = require('key-did-resolver')
 const Keystore = require('orbit-db-keystore')
@@ -13,7 +12,7 @@ const Identity = require('../src/identity')
 const keypath = path.resolve('./test/keys')
 let keystore
 
-const seed = new Uint8Array([ 157, 94, 116, 198, 19, 248, 93, 239, 173, 82, 245, 222, 199, 7, 183, 177, 123, 238, 83, 240, 143, 188, 87, 191, 33, 95, 58, 136, 46, 218, 219, 245 ])
+const seed = new Uint8Array([157, 94, 116, 198, 19, 248, 93, 239, 173, 82, 245, 222, 199, 7, 183, 177, 123, 238, 83, 240, 143, 188, 87, 191, 33, 95, 58, 136, 46, 218, 219, 245])
 const didStr = 'did:key:z6MkpnTJwrrVuphNh1uKb5DB7eRxvqniVaSDUHU6jtGVmn3r'
 
 const type = DIDIdentityProvider.type
@@ -32,7 +31,6 @@ describe('DID Identity Provider', function () {
 
   describe('create an DID identity', () => {
     let identity
-    let wallet
 
     before(async () => {
       const didProvider = new Ed25519Provider(seed)
@@ -65,7 +63,7 @@ describe('DID Identity Provider', function () {
     it('has a signature for the publicKey', async () => {
       const signingKey = await keystore.getKey(didStr)
       const idSignature = await keystore.sign(signingKey, didStr)
-      assert.notStrictEqual(identity.signatures.publicKey, undefined)
+      assert.notStrictEqual(idSignature, undefined)
     })
   })
 


### PR DESCRIPTION
This PR adds support for using DIDs as identities in OrbitDB. It uses the `dids` package under the hood, which relies on `EIP2844`.

In addition I changed to a smaller dependency for the EthIdentityProvider, and made sure to export the Ethereum and DID providers so they are accessible by developers.