### PR TITLE
Ability to restore Eth Identity from without Signer

### DIFF
--- a/src/identities.js
+++ b/src/identities.js
@@ -55,7 +55,7 @@ class Identities {
     const keystore = options.keystore || this.keystore
     const type = options.type || defaultType
     const identityProvider = type === defaultType ? new OrbitDBIdentityProvider(options.signingKeystore || keystore) : new (getHandlerFor(type))(options)
-    const id = await identityProvider.getId(options)
+    const id = options.id || await identityProvider.getId(options)
 
     if (options.migrate) {
       await options.migrate({ targetStore: keystore._store, targetId: id })


### PR DESCRIPTION
```js
import path from "path";
import ODBKeystore from "orbit-db-keystore";
import Identities from "orbit-db-identity-provider";

const account = accounts[0];
const odbIdentitykeysPath = path.join("./orbitdb", "identity", "identitykeys");
const keystore = new ODBKeystore(odbIdentitykeysPath);
// if account exist in IDB: restore else sign
const identity = await keystore.hasKey(account)
    ? await Identities.createIdentity({
        type: "orbitdb",
        id: account,
    })
   : await Identities.createIdentity({
        type: "ethereum",
        wallet: provider.getSigner(),
    });
```